### PR TITLE
fix: allow for optional spec parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.mytiki</groupId>
   <artifactId>ocean-catalog</artifactId>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <packaging>jar</packaging>
   <name>TIKI Ocean Catalog</name>
   <properties>


### PR DESCRIPTION
not all tables will have a timestamp for hourly partitions and they should but technically don't have to have an identity.